### PR TITLE
RYA-70 web.rya spring xml files don't pull in environment properties …

### DIFF
--- a/dao/accumulo.rya/src/main/java/org/apache/rya/accumulo/AccumuloRdfConfigurationBuilder.java
+++ b/dao/accumulo.rya/src/main/java/org/apache/rya/accumulo/AccumuloRdfConfigurationBuilder.java
@@ -69,26 +69,20 @@ public class AccumuloRdfConfigurationBuilder
      * @return AccumumuloRdfConfiguration with properties set
      */
     public static AccumuloRdfConfigurationBuilder fromProperties(Properties props) {
-        AccumuloRdfConfigurationBuilder builder = new AccumuloRdfConfigurationBuilder() //
-                .setAuths(props.getProperty(AbstractAccumuloRdfConfigurationBuilder.ACCUMULO_AUTHS, "")) //
-                .setRyaPrefix(props.getProperty(AbstractAccumuloRdfConfigurationBuilder.ACCUMULO_RYA_PREFIX, "rya_"))//
+        AccumuloRdfConfigurationBuilder builder = new AccumuloRdfConfigurationBuilder()
+                .setUseMockAccumulo(getBoolean(props.getProperty(AbstractAccumuloRdfConfigurationBuilder.USE_MOCK_ACCUMULO, "false")))
+                .setAccumuloInstance(props.getProperty(AbstractAccumuloRdfConfigurationBuilder.ACCUMULO_INSTANCE))
+                .setAccumuloZooKeepers(props.getProperty(AbstractAccumuloRdfConfigurationBuilder.ACCUMULO_ZOOKEEPERS))
+                .setAccumuloUser(props.getProperty(AbstractAccumuloRdfConfigurationBuilder.ACCUMULO_USER))
+                .setAccumuloPassword(props.getProperty(AbstractAccumuloRdfConfigurationBuilder.ACCUMULO_PASSWORD))
+                .setRyaPrefix(props.getProperty(AbstractAccumuloRdfConfigurationBuilder.ACCUMULO_RYA_PREFIX, "rya_"))
+                .setAuths(props.getProperty(AbstractAccumuloRdfConfigurationBuilder.ACCUMULO_AUTHS, ""))
                 .setVisibilities(props.getProperty(AbstractAccumuloRdfConfigurationBuilder.ACCUMULO_VISIBILITIES, ""))
-                .setUseInference(
-                        getBoolean(props.getProperty(AbstractAccumuloRdfConfigurationBuilder.USE_INFERENCE, "false")))//
-                .setDisplayQueryPlan(getBoolean(
-                        props.getProperty(AbstractAccumuloRdfConfigurationBuilder.USE_DISPLAY_QUERY_PLAN, "true")))//
-                .setAccumuloUser(props.getProperty(AbstractAccumuloRdfConfigurationBuilder.ACCUMULO_USER)) //
-                .setAccumuloInstance(props.getProperty(AbstractAccumuloRdfConfigurationBuilder.ACCUMULO_INSTANCE))//
-                .setAccumuloZooKeepers(props.getProperty(AbstractAccumuloRdfConfigurationBuilder.ACCUMULO_ZOOKEEPERS))//
-                .setAccumuloPassword(props.getProperty(AbstractAccumuloRdfConfigurationBuilder.ACCUMULO_PASSWORD))//
-                .setUseMockAccumulo(getBoolean(
-                        props.getProperty(AbstractAccumuloRdfConfigurationBuilder.USE_MOCK_ACCUMULO, "false")))//
-                .setUseAccumuloPrefixHashing(getBoolean(
-                        props.getProperty(AbstractAccumuloRdfConfigurationBuilder.USE_PREFIX_HASHING, "false")))//
-                .setUseCompositeCardinality(
-                        getBoolean(props.getProperty(AbstractAccumuloRdfConfigurationBuilder.USE_COUNT_STATS, "false")))//
-                .setUseJoinSelectivity(getBoolean(
-                        props.getProperty(AbstractAccumuloRdfConfigurationBuilder.USE_JOIN_SELECTIVITY, "false")));
+                .setUseAccumuloPrefixHashing(getBoolean(props.getProperty(AbstractAccumuloRdfConfigurationBuilder.USE_PREFIX_HASHING, "false")))
+                .setUseInference(getBoolean(props.getProperty(AbstractAccumuloRdfConfigurationBuilder.USE_INFERENCE, "false")))
+                .setDisplayQueryPlan(getBoolean(props.getProperty(AbstractAccumuloRdfConfigurationBuilder.USE_DISPLAY_QUERY_PLAN, "true")))
+                .setUseCompositeCardinality(getBoolean(props.getProperty(AbstractAccumuloRdfConfigurationBuilder.USE_COUNT_STATS, "false")))
+                .setUseJoinSelectivity(getBoolean(props.getProperty(AbstractAccumuloRdfConfigurationBuilder.USE_JOIN_SELECTIVITY, "false")));
         return builder;
     }
 

--- a/dao/accumulo.rya/src/test/java/org/apache/rya/accumulo/AccumuloRdfConfigurationTest.java
+++ b/dao/accumulo.rya/src/test/java/org/apache/rya/accumulo/AccumuloRdfConfigurationTest.java
@@ -19,8 +19,11 @@ package org.apache.rya.accumulo;
  * under the License.
  */
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.security.Authorizations;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -30,11 +33,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
-import org.apache.accumulo.core.client.IteratorSetting;
-import org.apache.accumulo.core.security.Authorizations;
-import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class AccumuloRdfConfigurationTest {
     private static final Logger logger = LoggerFactory.getLogger(AccumuloRdfConfigurationTest.class);
@@ -122,7 +122,7 @@ public class AccumuloRdfConfigurationTest {
 
     @Test
     public void testBuilderFromProperties() throws FileNotFoundException, IOException {
-        String prefix = "rya_";
+        String prefix = "ryatest_";
         String auth = "U";
         String visibility = "U";
         String user = "user";

--- a/dao/accumulo.rya/src/test/resources/properties/rya.properties
+++ b/dao/accumulo.rya/src/test/resources/properties/rya.properties
@@ -15,16 +15,16 @@
  # specific language governing permissions and limitations
  # under the License
  
-use.prefix.hashing true
-use.count.stats true
-use.join.selectivity true
-use.mock false
-use.display.plan false
-use.inference true
-accumulo.user user
-accumulo.password password
-accumulo.instance instance
-accumulo.zookeepers zookeeper
-accumulo.auths U
-accumulo.visibilities U
-accumuo.rya.prefix rya_
+use.prefix.hashing=true
+use.count.stats=true
+use.join.selectivity=true
+use.mock=false
+use.display.plan=false
+use.inference=true
+accumulo.user=user
+accumulo.password=password
+accumulo.instance=instance
+accumulo.zookeepers=zookeeper
+accumulo.auths=U
+accumulo.visibilities=U
+accumulo.rya.prefix=ryatest_

--- a/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/MongoDBRdfConfigurationBuilder.java
+++ b/dao/mongodb.rya/src/main/java/org/apache/rya/mongodb/MongoDBRdfConfigurationBuilder.java
@@ -68,25 +68,19 @@ public class MongoDBRdfConfigurationBuilder
     public static MongoDBRdfConfiguration fromProperties(Properties props) {
         try {
 
-            MongoDBRdfConfigurationBuilder builder = new MongoDBRdfConfigurationBuilder() //
-                    .setAuths(props.getProperty(AbstractMongoDBRdfConfigurationBuilder.MONGO_AUTHS, "")) //
-                    .setRyaPrefix(props.getProperty(AbstractMongoDBRdfConfigurationBuilder.MONGO_RYA_PREFIX, "rya_"))//
+            MongoDBRdfConfigurationBuilder builder = new MongoDBRdfConfigurationBuilder()
+                    .setRyaPrefix(props.getProperty(AbstractMongoDBRdfConfigurationBuilder.MONGO_RYA_PREFIX, "rya_"))
+                    .setAuths(props.getProperty(AbstractMongoDBRdfConfigurationBuilder.MONGO_AUTHS, ""))
                     .setVisibilities(props.getProperty(AbstractMongoDBRdfConfigurationBuilder.MONGO_VISIBILITIES, ""))
-                    .setUseInference(getBoolean(
-                            props.getProperty(AbstractMongoDBRdfConfigurationBuilder.USE_INFERENCE, "false")))//
-                    .setDisplayQueryPlan(getBoolean(
-                            props.getProperty(AbstractMongoDBRdfConfigurationBuilder.USE_DISPLAY_QUERY_PLAN, "true")))//
-                    .setMongoUser(props.getProperty(AbstractMongoDBRdfConfigurationBuilder.MONGO_USER)) //
-                    .setMongoPassword(props.getProperty(AbstractMongoDBRdfConfigurationBuilder.MONGO_PASSWORD))//
-                    .setMongoCollectionPrefix(
-                            props.getProperty(AbstractMongoDBRdfConfigurationBuilder.MONGO_COLLECTION_PREFIX, "rya_"))//
-                    .setMongoDBName(
-                            props.getProperty(AbstractMongoDBRdfConfigurationBuilder.MONGO_DB_NAME, "rya_triples"))//
-                    .setMongoHost(props.getProperty(AbstractMongoDBRdfConfigurationBuilder.MONGO_HOST, "localhost"))//
-                    .setMongoPort(props.getProperty(AbstractMongoDBRdfConfigurationBuilder.MONGO_PORT,
-                            AbstractMongoDBRdfConfigurationBuilder.DEFAULT_MONGO_PORT))//
-                    .setUseMockMongo(getBoolean(
-                            props.getProperty(AbstractMongoDBRdfConfigurationBuilder.USE_MOCK_MONGO, "false")));
+                    .setUseInference(getBoolean(props.getProperty(AbstractMongoDBRdfConfigurationBuilder.USE_INFERENCE, "false")))
+                    .setDisplayQueryPlan(getBoolean(props.getProperty(AbstractMongoDBRdfConfigurationBuilder.USE_DISPLAY_QUERY_PLAN, "true")))
+                    .setMongoUser(props.getProperty(AbstractMongoDBRdfConfigurationBuilder.MONGO_USER))
+                    .setMongoPassword(props.getProperty(AbstractMongoDBRdfConfigurationBuilder.MONGO_PASSWORD))
+                    .setMongoCollectionPrefix(props.getProperty(AbstractMongoDBRdfConfigurationBuilder.MONGO_COLLECTION_PREFIX, "rya_"))
+                    .setMongoDBName(props.getProperty(AbstractMongoDBRdfConfigurationBuilder.MONGO_DB_NAME, "rya_triples"))
+                    .setMongoHost(props.getProperty(AbstractMongoDBRdfConfigurationBuilder.MONGO_HOST, "localhost"))
+                    .setMongoPort(props.getProperty(AbstractMongoDBRdfConfigurationBuilder.MONGO_PORT, AbstractMongoDBRdfConfigurationBuilder.DEFAULT_MONGO_PORT))
+                    .setUseMockMongo(getBoolean(props.getProperty(AbstractMongoDBRdfConfigurationBuilder.USE_MOCK_MONGO, "false")));
 
             return builder.build();
         } catch (Exception e) {

--- a/dao/mongodb.rya/src/test/resources/rya.properties
+++ b/dao/mongodb.rya/src/test/resources/rya.properties
@@ -15,15 +15,14 @@
  # specific language governing permissions and limitations
  # under the License
 
-use.mock true
-use.display.plan false
-use.inference true
-mongo.user user
-mongo.password password
-mongo.host host
-mongo.port 1000
-mongo.auths U
-mongo.visibilities U
-mongo.db.name dbname
-mongo.collection.prefix prefix_
-
+use.mock=true
+use.display.plan=false
+use.inference=true
+mongo.user=user
+mongo.password=password
+mongo.host=host
+mongo.port=1000
+mongo.auths=U
+mongo.visibilities=U
+mongo.db.name=dbname
+mongo.collection.prefix=prefix_

--- a/extras/indexing/src/main/java/org/apache/rya/indexing/accumulo/AccumuloIndexingConfiguration.java
+++ b/extras/indexing/src/main/java/org/apache/rya/indexing/accumulo/AccumuloIndexingConfiguration.java
@@ -18,10 +18,8 @@
  */
 package org.apache.rya.indexing.accumulo;
 
-import java.util.HashSet;
-import java.util.Properties;
-import java.util.Set;
-
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.rya.accumulo.AbstractAccumuloRdfConfigurationBuilder;
@@ -35,8 +33,9 @@ import org.apache.rya.indexing.external.PrecomputedJoinIndexer;
 import org.apache.rya.indexing.statement.metadata.matching.StatementMetadataOptimizer;
 import org.eclipse.rdf4j.sail.Sail;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
 
 /**
  * This class is an extension of the AccumuloRdfConfiguration object used to to
@@ -399,38 +398,27 @@ public class AccumuloIndexingConfiguration extends AccumuloRdfConfiguration {
             Preconditions.checkNotNull(props);
             try {
                 final AccumuloIndexingConfigBuilder builder = new AccumuloIndexingConfigBuilder() //
-                        .setAuths(props.getProperty(AbstractAccumuloRdfConfigurationBuilder.ACCUMULO_AUTHS, "")) //
-                        .setRyaPrefix(
-                                props.getProperty(AbstractAccumuloRdfConfigurationBuilder.ACCUMULO_RYA_PREFIX, "rya_"))//
-                        .setVisibilities(
-                                props.getProperty(AbstractAccumuloRdfConfigurationBuilder.ACCUMULO_VISIBILITIES, ""))
-                        .setUseInference(getBoolean(
-                                props.getProperty(AbstractAccumuloRdfConfigurationBuilder.USE_INFERENCE, "false")))//
-                        .setDisplayQueryPlan(getBoolean(props
-                                .getProperty(AbstractAccumuloRdfConfigurationBuilder.USE_DISPLAY_QUERY_PLAN, "true")))//
-                        .setAccumuloUser(props.getProperty(AbstractAccumuloRdfConfigurationBuilder.ACCUMULO_USER)) //
-                        .setAccumuloInstance(
-                                props.getProperty(AbstractAccumuloRdfConfigurationBuilder.ACCUMULO_INSTANCE))//
-                        .setAccumuloZooKeepers(
-                                props.getProperty(AbstractAccumuloRdfConfigurationBuilder.ACCUMULO_ZOOKEEPERS))//
-                        .setAccumuloPassword(
-                                props.getProperty(AbstractAccumuloRdfConfigurationBuilder.ACCUMULO_PASSWORD))//
-                        .setUseMockAccumulo(getBoolean(
-                                props.getProperty(AbstractAccumuloRdfConfigurationBuilder.USE_MOCK_ACCUMULO, "false")))//
-                        .setUseAccumuloPrefixHashing(getBoolean(
-                                props.getProperty(AbstractAccumuloRdfConfigurationBuilder.USE_PREFIX_HASHING, "false")))//
-                        .setUseCompositeCardinality(getBoolean(
-                                props.getProperty(AbstractAccumuloRdfConfigurationBuilder.USE_COUNT_STATS, "false")))//
-                        .setUseJoinSelectivity(getBoolean(props
-                                .getProperty(AbstractAccumuloRdfConfigurationBuilder.USE_JOIN_SELECTIVITY, "false")))//
-                        .setUseAccumuloFreetextIndex(getBoolean(props.getProperty(USE_FREETEXT, "false")))//
-                        .setUseAccumuloTemporalIndex(getBoolean(props.getProperty(USE_TEMPORAL, "false")))//
-                        .setUseAccumuloEntityIndex(getBoolean(props.getProperty(USE_ENTITY, "false")))//
-                        .setAccumuloFreeTextPredicates(StringUtils.split(props.getProperty(FREETEXT_PREDICATES), ","))//
-                        .setAccumuloTemporalPredicates(StringUtils.split(props.getProperty(TEMPORAL_PREDICATES), ","))//
-                        .setUsePcj(getBoolean(props.getProperty(USE_PCJ, "false")))//
-                        .setUseOptimalPcj(getBoolean(props.getProperty(USE_OPTIMAL_PCJ, "false")))//
-                        .setPcjTables(StringUtils.split(props.getProperty(PCJ_TABLES), ","))//
+                        .setUseMockAccumulo(getBoolean(props.getProperty(AbstractAccumuloRdfConfigurationBuilder.USE_MOCK_ACCUMULO, "false")))
+                        .setRyaPrefix(props.getProperty(AbstractAccumuloRdfConfigurationBuilder.ACCUMULO_RYA_PREFIX, "rya_"))
+                        .setAuths(props.getProperty(AbstractAccumuloRdfConfigurationBuilder.ACCUMULO_AUTHS, ""))
+                        .setVisibilities(props.getProperty(AbstractAccumuloRdfConfigurationBuilder.ACCUMULO_VISIBILITIES, ""))
+                        .setUseInference(getBoolean(props.getProperty(AbstractAccumuloRdfConfigurationBuilder.USE_INFERENCE, "false")))
+                        .setDisplayQueryPlan(getBoolean(props.getProperty(AbstractAccumuloRdfConfigurationBuilder.USE_DISPLAY_QUERY_PLAN, "true")))
+                        .setAccumuloUser(props.getProperty(AbstractAccumuloRdfConfigurationBuilder.ACCUMULO_USER))
+                        .setAccumuloInstance(props.getProperty(AbstractAccumuloRdfConfigurationBuilder.ACCUMULO_INSTANCE))
+                        .setAccumuloZooKeepers(props.getProperty(AbstractAccumuloRdfConfigurationBuilder.ACCUMULO_ZOOKEEPERS))
+                        .setAccumuloPassword(props.getProperty(AbstractAccumuloRdfConfigurationBuilder.ACCUMULO_PASSWORD))
+                        .setUseAccumuloPrefixHashing(getBoolean(props.getProperty(AbstractAccumuloRdfConfigurationBuilder.USE_PREFIX_HASHING, "false")))
+                        .setUseCompositeCardinality(getBoolean(props.getProperty(AbstractAccumuloRdfConfigurationBuilder.USE_COUNT_STATS, "false")))
+                        .setUseJoinSelectivity(getBoolean(props.getProperty(AbstractAccumuloRdfConfigurationBuilder.USE_JOIN_SELECTIVITY, "false")))
+                        .setUseAccumuloFreetextIndex(getBoolean(props.getProperty(USE_FREETEXT, "false")))
+                        .setUseAccumuloTemporalIndex(getBoolean(props.getProperty(USE_TEMPORAL, "false")))
+                        .setUseAccumuloEntityIndex(getBoolean(props.getProperty(USE_ENTITY, "false")))
+                        .setAccumuloFreeTextPredicates(StringUtils.split(props.getProperty(FREETEXT_PREDICATES), ","))
+                        .setAccumuloTemporalPredicates(StringUtils.split(props.getProperty(TEMPORAL_PREDICATES), ","))
+                        .setUsePcj(getBoolean(props.getProperty(USE_PCJ, "false")))
+                        .setUseOptimalPcj(getBoolean(props.getProperty(USE_OPTIMAL_PCJ, "false")))
+                        .setPcjTables(StringUtils.split(props.getProperty(PCJ_TABLES), ","))
                         .setPcjUpdaterFluoAppName(props.getProperty(FLUO_APP_NAME))
                         .setUseStatementMetadata(getBoolean(props.getProperty(USE_STATEMENT_METADATA)))
                         .setStatementMetadataProperties(getPropURIFromStrings(StringUtils.split(props.getProperty(STATEMENT_METADATA_PROPERTIES), ",")));

--- a/extras/indexing/src/main/java/org/apache/rya/indexing/mongodb/MongoIndexingConfiguration.java
+++ b/extras/indexing/src/main/java/org/apache/rya/indexing/mongodb/MongoIndexingConfiguration.java
@@ -18,8 +18,7 @@
  */
 package org.apache.rya.indexing.mongodb;
 
-import java.util.Properties;
-
+import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.rya.indexing.accumulo.ConfigUtils;
@@ -31,7 +30,7 @@ import org.apache.rya.mongodb.MongoDBRdfConfiguration;
 import org.apache.rya.mongodb.MongoDBRdfConfigurationBuilder;
 import org.eclipse.rdf4j.sail.Sail;
 
-import com.google.common.base.Preconditions;
+import java.util.Properties;
 
 /**
  * This class is an extension of the MongoDBRdfConfiguration object used to to
@@ -269,29 +268,22 @@ public class MongoIndexingConfiguration extends MongoDBRdfConfiguration {
         public static MongoIndexingConfiguration fromProperties(final Properties props) {
             try {
                 final MongoDBIndexingConfigBuilder builder = new MongoDBIndexingConfigBuilder() //
-                        .setAuths(props.getProperty(AbstractMongoDBRdfConfigurationBuilder.MONGO_AUTHS, "")) //
-                        .setRyaPrefix(
-                                props.getProperty(AbstractMongoDBRdfConfigurationBuilder.MONGO_RYA_PREFIX, "rya_"))//
+                        .setUseMockMongo(getBoolean(props.getProperty(AbstractMongoDBRdfConfigurationBuilder.USE_MOCK_MONGO, "false")))
+                        .setRyaPrefix(props.getProperty(AbstractMongoDBRdfConfigurationBuilder.MONGO_RYA_PREFIX, "rya_"))
+                        .setAuths(props.getProperty(AbstractMongoDBRdfConfigurationBuilder.MONGO_AUTHS, ""))
                         .setVisibilities(props.getProperty(AbstractMongoDBRdfConfigurationBuilder.MONGO_VISIBILITIES, ""))
-                        .setUseInference(getBoolean(
-                                props.getProperty(AbstractMongoDBRdfConfigurationBuilder.USE_INFERENCE, "false")))//
-                        .setDisplayQueryPlan(getBoolean(props
-                                .getProperty(AbstractMongoDBRdfConfigurationBuilder.USE_DISPLAY_QUERY_PLAN, "true")))//
-                        .setMongoUser(props.getProperty(AbstractMongoDBRdfConfigurationBuilder.MONGO_USER)) //
-                        .setMongoPassword(props.getProperty(AbstractMongoDBRdfConfigurationBuilder.MONGO_PASSWORD))//
-                        .setMongoCollectionPrefix(props
-                                .getProperty(AbstractMongoDBRdfConfigurationBuilder.MONGO_COLLECTION_PREFIX, "rya_"))//
-                        .setMongoDBName(
-                                props.getProperty(AbstractMongoDBRdfConfigurationBuilder.MONGO_DB_NAME, "rya_triples"))//
-                        .setMongoHost(props.getProperty(AbstractMongoDBRdfConfigurationBuilder.MONGO_HOST, "localhost"))//
-                        .setMongoPort(props.getProperty(AbstractMongoDBRdfConfigurationBuilder.MONGO_PORT,
-                                AbstractMongoDBRdfConfigurationBuilder.DEFAULT_MONGO_PORT))//
-                        .setUseMockMongo(getBoolean(
-                                props.getProperty(AbstractMongoDBRdfConfigurationBuilder.USE_MOCK_MONGO, "false")))//
-                        .setUseMongoFreetextIndex(getBoolean(props.getProperty(USE_FREETEXT, "false")))//
-                        .setUseMongoTemporalIndex(getBoolean(props.getProperty(USE_TEMPORAL, "false")))//
-                        .setUseMongoEntityIndex(getBoolean(props.getProperty(USE_ENTITY, "false")))//
-                        .setMongoFreeTextPredicates(StringUtils.split(props.getProperty(FREETEXT_PREDICATES), ","))//
+                        .setUseInference(getBoolean(props.getProperty(AbstractMongoDBRdfConfigurationBuilder.USE_INFERENCE, "false")))
+                        .setDisplayQueryPlan(getBoolean(props.getProperty(AbstractMongoDBRdfConfigurationBuilder.USE_DISPLAY_QUERY_PLAN, "true")))
+                        .setMongoUser(props.getProperty(AbstractMongoDBRdfConfigurationBuilder.MONGO_USER))
+                        .setMongoPassword(props.getProperty(AbstractMongoDBRdfConfigurationBuilder.MONGO_PASSWORD))
+                        .setMongoCollectionPrefix(props.getProperty(AbstractMongoDBRdfConfigurationBuilder.MONGO_COLLECTION_PREFIX, "rya_"))
+                        .setMongoDBName(props.getProperty(AbstractMongoDBRdfConfigurationBuilder.MONGO_DB_NAME, "rya_triples"))
+                        .setMongoHost(props.getProperty(AbstractMongoDBRdfConfigurationBuilder.MONGO_HOST, "localhost"))
+                        .setMongoPort(props.getProperty(AbstractMongoDBRdfConfigurationBuilder.MONGO_PORT, AbstractMongoDBRdfConfigurationBuilder.DEFAULT_MONGO_PORT))
+                        .setUseMongoFreetextIndex(getBoolean(props.getProperty(USE_FREETEXT, "false")))
+                        .setUseMongoTemporalIndex(getBoolean(props.getProperty(USE_TEMPORAL, "false")))
+                        .setUseMongoEntityIndex(getBoolean(props.getProperty(USE_ENTITY, "false")))
+                        .setMongoFreeTextPredicates(StringUtils.split(props.getProperty(FREETEXT_PREDICATES), ","))
                         .setMongoTemporalPredicates(StringUtils.split(props.getProperty(TEMPORAL_PREDICATES), ","));
 
                 return builder.build();

--- a/extras/indexing/src/test/java/org/apache/rya/indexing/accumulo/AccumuloIndexingConfigurationTest.java
+++ b/extras/indexing/src/test/java/org/apache/rya/indexing/accumulo/AccumuloIndexingConfigurationTest.java
@@ -18,8 +18,9 @@
  */
 package org.apache.rya.indexing.accumulo;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.rya.api.domain.RyaIRI;
+import org.junit.Test;
 
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -29,9 +30,8 @@ import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
 
-import org.apache.accumulo.core.security.Authorizations;
-import org.apache.rya.api.domain.RyaIRI;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class AccumuloIndexingConfigurationTest {
 
@@ -101,7 +101,7 @@ public class AccumuloIndexingConfigurationTest {
 
     @Test
     public void testBuilderFromProperties() throws FileNotFoundException, IOException {
-        String prefix = "rya_";
+        String prefix = "ryatest_";
         String auth = "U";
         String visibility = "U";
         String user = "user";

--- a/extras/indexing/src/test/resources/accumulo_rya_indexing.properties
+++ b/extras/indexing/src/test/resources/accumulo_rya_indexing.properties
@@ -15,26 +15,26 @@
  # specific language governing permissions and limitations
  # under the License
 
-use.prefix.hashing true
-use.count.stats true
-use.join.selectivity true
-use.mock false
-use.display.plan false
-use.inference true
-accumulo.user user
-accumulo.password password
-accumulo.instance instance
-accumulo.zookeepers zookeeper
-accumulo.auths U
-accumulo.visibilities U
-accumuo.rya.prefix rya_
-use.freetext true
-use.entity true
-use.temporal true
-use.optimal.pcj true
-freetext.predicates http://pred1,http://pred2
-temporal.predicates http://pred3,http://pred4
-pcj.tables table1,table2
-fluo.app.name fluo
-use.metadata true
-metadata.properties urn:123,urn:456
+use.prefix.hashing=true
+use.count.stats=true
+use.join.selectivity=true
+use.mock=false
+use.display.plan=false
+use.inference=true
+accumulo.user=user
+accumulo.password=password
+accumulo.instance=instance
+accumulo.zookeepers=zookeeper
+accumulo.auths=U
+accumulo.visibilities=U
+accumulo.rya.prefix=ryatest_
+use.freetext=true
+use.entity=true
+use.temporal=true
+use.optimal.pcj=true
+freetext.predicates=http://pred1,http://pred2
+temporal.predicates=http://pred3,http://pred4
+pcj.tables=table1,table2
+fluo.app.name=fluo
+use.metadata=true
+metadata.properties=urn:123,urn:456

--- a/extras/indexing/src/test/resources/mongo_rya_indexing.properties
+++ b/extras/indexing/src/test/resources/mongo_rya_indexing.properties
@@ -15,19 +15,19 @@
  # specific language governing permissions and limitations
  # under the License.
  
-use.mock true
-use.display.plan false
-use.inference true
-mongo.user user
-mongo.password password
-mongo.host host
-mongo.port 1000
-mongo.auths U
-mongo.visibilities U
-mongo.db.name dbname
-mongo.collection.prefix prefix_
-use.freetext true
-use.temporal true
-use.entity true
-freetext.predicates http://pred1,http://pred2
-temporal.predicates http://pred3,http://pred4
+use.mock=true
+use.display.plan=false
+use.inference=true
+mongo.user=user
+mongo.password=password
+mongo.host=host
+mongo.port=1000
+mongo.auths=U
+mongo.visibilities=U
+mongo.db.name=dbname
+mongo.collection.prefix=prefix_
+use.freetext=true
+use.temporal=true
+use.entity=true
+freetext.predicates=http://pred1,http://pred2
+temporal.predicates=http://pred3,http://pred4

--- a/web/web.rya/src/main/webapp/WEB-INF/classes/accumulo.properties
+++ b/web/web.rya/src/main/webapp/WEB-INF/classes/accumulo.properties
@@ -1,0 +1,43 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+use.mock=false
+accumulo.instance=muchos
+accumulo.zookeepers=leader1:2181
+accumulo.user=root
+accumulo.password=secret
+accumulo.rya.prefix=rya_
+#accumulo.rya.prefix=lubm_
+accumulo.auths=U
+accumulo.visibilities=U
+
+instance.name=muchos
+instance.zk=leader1:2181
+instance.username=root
+instance.password=secret
+
+rya.tableprefix=rya_
+#rya.tableprefix=lubm_
+rya.displayqueryplan=true
+rya.usestats=true
+rya.useselectivity=false
+rya.usestatementmetadata=false
+rya.querythreads=200
+rya.querythreadsperserver=10
+rya.batchsize=1000

--- a/web/web.rya/src/main/webapp/WEB-INF/classes/extensions.properties
+++ b/web/web.rya/src/main/webapp/WEB-INF/classes/extensions.properties
@@ -1,0 +1,77 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License
+
+use.mock=false
+accumulo.instance=muchos
+accumulo.zookeepers=leader1:2181
+accumulo.user=root
+accumulo.password=secret
+accumulo.rya.prefix=rya_
+#accumulo.rya.prefix=lubm_
+accumulo.auths=U
+accumulo.visibilities=U
+use.prefix.hashing=false
+use.inference=true
+use.display.plan=true
+use.count.stats=true
+use.join.selectivity=true
+use.freetext=true
+use.entity=true
+use.temporal=true
+use.optimal.pcj=true
+freetext.predicates=http://pred1,http://pred2
+temporal.predicates=http://pred3,http://pred4
+pcj.tables=table1,table2
+fluo.app.name=fluo
+use.metadata=false
+metadata.properties=urn:123,urn:456
+
+instance.name=muchos
+instance.zk=leader1:2181
+instance.username=root
+instance.password=secret
+rya.tableprefix=rya_
+#rya.tableprefix=lubm_
+rya.displayqueryplan=true
+rya.usestats=true
+rya.useselectivity=true
+rya.usestatementmetadata=false
+rya.querythreads=2000
+rya.querythreadsperserver=100
+rya.batchsize=10000
+rya.datawaveedge=true
+
+sc.cloudbase.instancename=muchos
+sc.cloudbase.zookeepers=leader1:2181
+sc.cloudbase.username=root
+sc.cloudbase.password=secret
+query.tblprefix=rya_
+
+sc.use_entity=true
+sc.use.indexing.sail=true
+sc.use_freetext=true
+sc.freetext.doctable=rya_freetext
+sc.freetext.termtable=rya_freetext_term
+sc.use_geo=false
+sc.geo.table=rya_geo
+sc.cloudbase.numPartitions=3
+sc.geo.numPartitions=3
+sc.use_temporal=true
+sc.temporal.index=rya_temporal
+sc.geo.predicates=http://www.opengis.net/ont/geosparql#asWKT,http://www.opengis.net/ont/geosparql#asGML
+sc.freetext.predicates=TODO,predicate-url's,that,are,comma,delimited
+sc.temporal.predicates=TODO,can't be blank, but missing is fine.

--- a/web/web.rya/src/main/webapp/WEB-INF/classes/log4j.properties
+++ b/web/web.rya/src/main/webapp/WEB-INF/classes/log4j.properties
@@ -1,0 +1,45 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Valid levels:
+# TRACE, DEBUG, INFO, WARN, ERROR and FATAL
+log4j.rootLogger=INFO, R
+
+log4j.appender.R=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.R.File=${catalina.home}/logs/rya.log
+log4j.appender.R.DatePattern='.'yyyy-MM-dd 
+
+log4j.appender.R.layout=org.apache.log4j.PatternLayout
+log4j.appender.R.layout.ConversionPattern=%d [%t] %-5p %c - %m%n
+
+log4j.logger.org.apache.catalina=INFO, R
+log4j.logger.org.apache.catalina.core.ContainerBase.[Catalina].[localhost]=INFO, R
+log4j.logger.org.apache.catalina.core=INFO, R
+log4j.logger.org.apache.catalina.session=INFO, R
+
+log4j.logger.org.apache.zookeeper=INFO, R
+
+log4j.logger.org.apache.rya=INFO, R
+log4j.additivity.org.apache.rya=false
+
+log4j.logger.org.apache.rya.accumulo.query=INFO, R
+log4j.additivity.org.apache.rya.accumulo.query=false
+
+log4j.logger.org.apache.rya.rdftriplestore.evaluation=INFO, R
+log4j.additivity.org.apache.rya.rdftriplestore.evaluation=false

--- a/web/web.rya/src/main/webapp/WEB-INF/spring/spring-accumulo.xml
+++ b/web/web.rya/src/main/webapp/WEB-INF/spring/spring-accumulo.xml
@@ -20,32 +20,26 @@ under the License.
 -->
 
 <beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xmlns:oxm="http://www.springframework.org/schema/oxm"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd
-				http://www.springframework.org/schema/oxm http://www.springframework.org/schema/oxm/spring-oxm-3.0.xsd">
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
 
-	<bean id="zkInstance" class="org.apache.accumulo.core.client.ZooKeeperInstance" >
+    <bean id="zkInstance" class="org.apache.accumulo.core.client.ZooKeeperInstance">
         <constructor-arg value="${instance.name}"/>
         <constructor-arg value="${instance.zk}"/>
     </bean>
 
-    <bean id="connector" factory-bean="zkInstance"
-          factory-method="getConnector">
+    <bean id="connector" factory-bean="zkInstance" factory-method="getConnector">
         <constructor-arg value="${instance.username}"/>
         <constructor-arg value="${instance.password}"/>
     </bean>
 
-    <bean id="conf" class="org.apache.rya.accumulo.AccumuloRdfConfiguration">
-        <property name="tablePrefix" value="${rya.tableprefix}"/>
-        <property name="displayQueryPlan" value="${rya.displayqueryplan}"/>
-        <property name="useStats" value="false"/>
+    <bean id="conf" class="org.apache.rya.accumulo.AccumuloRdfConfiguration" factory-method="fromProperties">
+        <constructor-arg ref="properties"/>
     </bean>
 
-	<bean id="ryaDAO" class="org.apache.rya.accumulo.AccumuloRyaDAO" init-method="init" destroy-method="destroy">
-	    <property name="connector" ref="connector"/>
+    <bean id="ryaDAO" class="org.apache.rya.accumulo.AccumuloRyaDAO" init-method="init" destroy-method="destroy">
+        <property name="connector" ref="connector"/>
         <property name="conf" ref="conf"/>
     </bean>
+
 </beans>

--- a/web/web.rya/src/main/webapp/WEB-INF/spring/spring-mongodb-geo.xml
+++ b/web/web.rya/src/main/webapp/WEB-INF/spring/spring-mongodb-geo.xml
@@ -20,13 +20,11 @@ under the License.
 -->
 
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
-    xmlns:context="http://www.springframework.org/schema/context"
-    xmlns:oxm="http://www.springframework.org/schema/oxm"
-    xmlns:hdp="http://www.springframework.org/schema/hadoop"
-    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd
-                http://www.springframework.org/schema/oxm http://www.springframework.org/schema/oxm/spring-oxm-3.0.xsd
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:hdp="http://www.springframework.org/schema/hadoop"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+
+
                 http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 

--- a/web/web.rya/src/main/webapp/WEB-INF/spring/spring-mongodb.xml
+++ b/web/web.rya/src/main/webapp/WEB-INF/spring/spring-mongodb.xml
@@ -20,19 +20,14 @@ under the License.
 -->
 
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
-    xmlns:context="http://www.springframework.org/schema/context"
-    xmlns:oxm="http://www.springframework.org/schema/oxm"
-    xmlns:hdp="http://www.springframework.org/schema/hadoop"
-    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd
-                http://www.springframework.org/schema/oxm http://www.springframework.org/schema/oxm/spring-oxm-3.0.xsd
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:hdp="http://www.springframework.org/schema/hadoop"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
                 http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
-
-     <hdp:configuration id="hadoopConf">
+    <hdp:configuration id="hadoopConf" properties-location="classpath:environment.properties">
         sc.useMongo=true
-      </hdp:configuration>
+    </hdp:configuration>
 
     <bean id="conf" class="org.apache.rya.mongodb.MongoDBRdfConfiguration">
         <constructor-arg ref="hadoopConf"/>
@@ -44,7 +39,7 @@ under the License.
         <property name="displayQueryPlan" value="${rya.displayqueryplan}"/>
         <property name="useStats" value="false"/>
     </bean>
-    
+
     <bean id="sail" class="org.apache.rya.sail.config.RyaSailFactory" factory-method="getInstance">
         <constructor-arg ref="conf"/>
     </bean>

--- a/web/web.rya/src/main/webapp/WEB-INF/spring/spring-root-accumulo.xml
+++ b/web/web.rya/src/main/webapp/WEB-INF/spring/spring-root-accumulo.xml
@@ -20,21 +20,20 @@ under the License.
 -->
 
 <beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xmlns:util="http://www.springframework.org/schema/util"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd
-				http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.0.xsd">
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.2.xsd
+                http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.2.xsd">
 
-    <bean id="environmentProperties" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
-        <property name="location" value="classpath:environment.properties"/>
-    </bean>
+    <util:properties id="properties" location="classpath:accumulo.properties"/>
+    <context:property-placeholder properties-ref="properties"/>
 
-	<context:component-scan base-package="org.apache.cloud.rdf.web.sail" />
+    <context:component-scan base-package="org.apache.cloud.rdf.web.sail"/>
 
-	<import resource="spring-security.xml"/>	
-	<import resource="spring-accumulo.xml"/>
+    <import resource="spring-accumulo.xml"/>
+	<import resource="spring-security.xml"/>
 
 	<bean id="inferenceEngine" class="org.apache.rya.rdftriplestore.inference.InferenceEngine" init-method="init" destroy-method="destroy">
         <property name="ryaDAO" ref="ryaDAO"/>
@@ -55,14 +54,15 @@ under the License.
         <property name="conf" ref="conf"/>
     </bean>
 
-	<bean id="rts" class="org.apache.rya.rdftriplestore.RdfCloudTripleStore">
-        <property name="ryaDAO" ref="ryaDAO"/>
-        <property name="rdfEvalStatsDAO" ref="rdfEvalStatsDAO"/>
-        <property name="inferenceEngine" ref="inferenceEngine"/>
+    <bean id="ryaSail" class="org.apache.rya.rdftriplestore.RdfCloudTripleStore">
         <property name="conf" ref="conf"/>
-	</bean>
+        <property name="ryaDAO" ref="ryaDAO"/>
+        <property name="inferenceEngine" ref="inferenceEngine"/>
+        <property name="rdfEvalStatsDAO" ref="rdfEvalStatsDAO"/>
+    </bean>
 
 	<bean id="sailRepo" class="org.apache.rya.rdftriplestore.RyaSailRepository" init-method="initialize" destroy-method="shutDown">
-        <constructor-arg ref="rts"/>
+        <constructor-arg ref="ryaSail"/>
 	</bean>
+
 </beans>

--- a/web/web.rya/src/main/webapp/WEB-INF/spring/spring-root-extensions.xml
+++ b/web/web.rya/src/main/webapp/WEB-INF/spring/spring-root-extensions.xml
@@ -20,86 +20,97 @@ under the License.
 -->
 
 <beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xmlns:util="http://www.springframework.org/schema/util"
-    xmlns:hdp="http://www.springframework.org/schema/hadoop"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
-				http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.1.xsd
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xmlns:hdp="http://www.springframework.org/schema/hadoop"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.2.xsd
+                http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.2.xsd
                 http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
-    <bean id="environmentProperties" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
-        <property name="location" value="classpath:environment.properties"/>
+    <util:properties id="properties" location="classpath:extensions.properties"/>
+    <context:property-placeholder properties-ref="properties"/>
+
+    <context:component-scan base-package="org.apache.cloud.rdf.web.sail"/>
+
+    <import resource="spring-accumulo.xml"/>
+    <import resource="spring-security.xml"/>
+
+    <hdp:configuration id="hadoopConf" properties-location="classpath:extensions.properties"/>
+    <!--
+    <hdp:configuration id="hadoopConf">
+        sc.cloudbase.instancename=${instance.name}
+        sc.cloudbase.zookeepers=${instance.zk}
+        sc.cloudbase.username=${instance.username}
+        sc.cloudbase.password=${instance.password}
+
+        query.printqueryplan=${rya.displayqueryplan}
+
+        sc.freetext.doctable=${sc.freetext.doctable}
+        sc.freetext.termtable=${sc.freetext.termtable}
+        sc.geo.table=${sc.geo.table}
+        sc.geo.predicates=${sc.geo.predicates}
+        sc.geo.numPartitions=${sc.geo.numPartitions}
+        sc.temporal.index=${sc.temporal.index}
+
+        query.usestats=false
+        query.useselectivity=false
+        query.usecompositecard=false
+    </hdp:configuration>
+    -->
+
+    <bean id="indexerSettings" class="org.apache.rya.indexing.accumulo.AccumuloIndexingConfiguration" factory-method="fromProperties">
+        <constructor-arg ref="properties"/>
     </bean>
 
-	<context:component-scan base-package="org.apache.cloud.rdf.web.sail" />
-	
-	<import resource="spring-accumulo.xml"/>
-    <import resource="spring-security.xml"/>    
-  
-  <hdp:configuration id="hadoopConf">
-    sc.cloudbase.instancename=${instance.name}
-    sc.cloudbase.zookeepers=${instance.zk}
-    sc.cloudbase.username=${instance.username}
-    sc.cloudbase.password=${instance.password}
-
-    query.printqueryplan=${rya.displayqueryplan}
-
-    sc.freetext.doctable=${sc.freetext.doctable}
-    sc.freetext.termtable=${sc.freetext.termtable}
-    sc.geo.table=${sc.geo.table}
-    sc.geo.predicates=${sc.geo.predicates}
-    sc.geo.numPartitions=${sc.geo.numPartitions}
-    sc.temporal.index=${sc.temporal.index}
-    
-    query.usestats=false
-    query.useselectivity=false
-    query.usecompositecard=false
-  </hdp:configuration>  
-
-<!-- inference Engine is disabled -->  
-<!-- 
-	<bean id="inferenceEngine" class="org.apache.rya.rdftriplestore.inference.InferenceEngine" init-method="init" destroy-method="destroy">
+    <bean id="inferenceEngine" class="org.apache.rya.rdftriplestore.inference.InferenceEngine" init-method="init" destroy-method="destroy">
         <property name="ryaDAO" ref="ryaDAO"/>
-        <property name="conf" ref="conf"/>
-	</bean>
-    
-    <bean id="prospectTableName" class="org.apache.rya.prospector.service.ProspectorServiceEvalStatsDAO" factory-method="getProspectTableName">
-        <constructor-arg ref="conf"/>
+        <property name="conf" ref="indexerSettings"/>
     </bean>
-    
+
+    <bean id="prospectTableName" class="org.apache.rya.prospector.service.ProspectorServiceEvalStatsDAO" factory-method="getProspectTableName">
+        <constructor-arg ref="indexerSettings"/>
+    </bean>
+
     <bean id="prospectorService" class="org.apache.rya.prospector.service.ProspectorService">
         <constructor-arg ref="connector"/>
         <constructor-arg ref="prospectTableName"/>
     </bean>
-    
-    <bean id="rdfEvalStatsDAO" class="org.apache.rya.prospector.service.ProspectorServiceEvalStatsDAO">
+
+    <bean id="rdfEvalStatsDAO" class="org.apache.rya.prospector.service.ProspectorServiceEvalStatsDAO" init-method="init" destroy-method="destroy">
         <property name="prospectorService" ref="prospectorService"/>
-        <property name="conf" ref="conf"/>
+        <property name="conf" ref="indexerSettings"/>
     </bean>
- -->
- 
-	<bean id="ryaSail" class="org.apache.rya.rdftriplestore.RdfCloudTripleStore">
+
+    <bean id="selectEvalDAO" class="org.apache.rya.joinselect.AccumuloSelectivityEvalDAO" init-method="init" destroy-method="destroy">
+        <property name="conf" ref="indexerSettings"/>
+        <property name="connector" ref="connector"/>
+        <property name="rdfEvalDAO" ref="rdfEvalStatsDAO"/>
+    </bean>
+
+    <bean id="ryaSail" class="org.apache.rya.rdftriplestore.RdfCloudTripleStore">
+        <property name="conf" ref="indexerSettings"/>
         <property name="ryaDAO" ref="ryaDAO"/>
-<!-- 
-        <property name="rdfEvalStatsDAO" ref="rdfEvalStatsDAO"/>
         <property name="inferenceEngine" ref="inferenceEngine"/>
- -->
-         <property name="conf" ref="conf"/>
-	</bean>
-
-    <bean id="indexerSettings" class="org.apache.rya.indexing.accumulo.AccumuloIndexerSettings">
-        <constructor-arg ref="hadoopConf"/>
+        <property name="rdfEvalStatsDAO" ref="rdfEvalStatsDAO"/>
+        <property name="selectEvalDAO" ref="selectEvalDAO"/>
     </bean>
 
-    <bean id="ryaIndexingSail" class="org.apache.rya.indexing.accumulo.RyaIndexingSail">
-        <constructor-arg ref="hadoopConf"/>
-        <constructor-arg ref="ryaSail"/>
+    <!--
+    <bean id="ryaIndexingSail" class="org.apache.rya.sail.config.RyaSailFactory" factory-method="getInstance">
         <constructor-arg ref="indexerSettings"/>
     </bean>
+    -->
 
+    <!--
     <bean id="indexingSailRepo" class="org.eclipse.rdf4j.repository.sail.SailRepository" init-method="initialize" destroy-method="shutDown">
         <constructor-arg ref="ryaIndexingSail"/>
     </bean>
+    -->
+
+    <bean id="indexingSailRepo" class="org.apache.rya.rdftriplestore.RyaSailRepository" init-method="initialize" destroy-method="shutDown">
+        <constructor-arg ref="ryaSail"/>
+    </bean>
+
 </beans>

--- a/web/web.rya/src/main/webapp/WEB-INF/spring/spring-root-mongodb-geo.xml
+++ b/web/web.rya/src/main/webapp/WEB-INF/spring/spring-root-mongodb-geo.xml
@@ -20,12 +20,10 @@ under the License.
 -->
 
 <beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xmlns:util="http://www.springframework.org/schema/util"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd
-				http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.0.xsd">
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="http://www.springframework.org/schema/context"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
     <bean id="environmentProperties" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
         <property name="location" value="classpath:environment.properties"/>

--- a/web/web.rya/src/main/webapp/WEB-INF/spring/spring-root-mongodb.xml
+++ b/web/web.rya/src/main/webapp/WEB-INF/spring/spring-root-mongodb.xml
@@ -20,12 +20,10 @@ under the License.
 -->
 
 <beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xmlns:util="http://www.springframework.org/schema/util"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd
-				http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.0.xsd">
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="http://www.springframework.org/schema/context"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
     <bean id="environmentProperties" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
         <property name="location" value="classpath:environment.properties"/>

--- a/web/web.rya/src/main/webapp/WEB-INF/spring/spring-security.xml
+++ b/web/web.rya/src/main/webapp/WEB-INF/spring/spring-security.xml
@@ -20,12 +20,10 @@ under the License.
 -->
 
 <beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xmlns:oxm="http://www.springframework.org/schema/oxm"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd
-				http://www.springframework.org/schema/oxm http://www.springframework.org/schema/oxm/spring-oxm-3.0.xsd">
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="http://www.springframework.org/schema/context"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:annotation-config/>
 


### PR DESCRIPTION
…consistently to a well-defined standard. This commit begins to tidy the Accumulo config (MongoDB to come) but more work is required.

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
## Description
>What Changed?

This pull request is a DRAFT seeking feedback from the community.

The current structure and documentation concerning the environment.properties and spring xml configuration seems to be lacking. Trying to get advanced features working in Tomcat, for example the AccumuloSelectivityEvalDAO or the various indexing strategies, is a very hard slog, particularly for new comers to the project.

I've started to tidy up the accumulo and extension spring xml files. I've tested the accumulo and extensions files on a test cluster. I'm not 100% sure the AccumuloSelectivityEvalDAO is working fully, but it seems to be running. I've got a different branch of Rya that contains a bunch of debug logging that I will try tomorrow.

I propose we add default properties files to the project that work out of the box with Fluo Muchos (or similar) to allow for easy spin up of a development cluster to give Rya a whirl, for example on AWS or Azure. People can then easily edit them to their environment, rather than having to reverse engineer what parameters are available and what default values are in use.

I'm happy to do MongoDB configuration too but I don't have a test cluster running at present.

I'm after feedback from more experienced developers of Rya about whether these changes are heading in the correct direction. For example, I've replaced some of the configuration xml calling setter methods like this:

```
    <bean id="conf" class="org.apache.rya.accumulo.AccumuloRdfConfiguration">
        <!-- Calls setter method name -->
        <property name="tablePrefix" value="${rya.tableprefix}"/>
        <property name="displayQueryPlan" value="${rya.displayqueryplan}"/>
        <property name="useStats" value="false"/>
        <property name="useStats" value="${rya.usestats}"/>
        <property name="useSelectivity" value="${rya.useselectivity}"/>
        <property name="useStatementMetadata" value="${rya.usestatementmetadata}"/>
        <property name="numThreads" value="${rya.querythreads}"/>
        <property name="batchSize" value="${rya.batchsize}"/>
        <property name="dataWaveEdge" value="${rya.datawaveedge}"/>
        <property name="dataType" value="org.eclipse.rdf4j.model.Statement"/>
        <!--
        <property name="useEntity" value="${sc.use_entity}"/>
        <property name="useGeo" value="${sc.use_geo}"/>
        <property name="useFreeText" value="${sc.use_freetext}"/>
        <property name="useTemporal" value="${sc.use_temporal}"/>
        -->
    </bean>
```
 with 
```
    <bean id="conf" class="org.apache.rya.accumulo.AccumuloRdfConfiguration" factory-method="fromProperties">
        <constructor-arg ref="properties"/>
    </bean>
```

Additionally, there is a lot of duplication in the properties space. I'm trying understand why. I'm also trying to understand the differences.

For example, there are environment properties `accumulo.instance`, `instance.name` and `sc.cloudbase.instancename` in different places, all obviously referring to the same type of thing? Is this redundancy deliberate, or can I start consolidating it down? Can we get down to a single Rya configuration properties file for an entire Rya installation (e.g. ingest jobs, Tomcat, Fluo, etc)?

I'm still a little lost in the details here, and any background or advice would be much appreciated.

### Tests
>Coverage?

N/A

### Links
[Jira RYA-70](https://issues.apache.org/jira/browse/RYA-70)

### Checklist
- [ ] Code Review
- [ ] Squash Commits

#### People To Reivew
[Add those who should review this]
