### PR TITLE
graduation clean-up:removed DISCLAIMER file, removed incubating name,…

### DIFF
--- a/DISCLAIMER
+++ b/DISCLAIMER
@@ -1,8 +1,0 @@
-Apache Rya is an effort undergoing incubation at The Apache Software
-Foundation (ASF), sponsored by the Apache Incubator PMC. Incubation is
-required of all newly accepted projects until a further review indicates
-that the infrastructure, communications, and decision making process have
-stabilized in a manner consistent with other successful ASF projects. While
-incubation status is not necessarily a reflection of the completeness or
-stability of the code, it does indicate that the project has yet to be
-fully endorsed by the ASF.

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Apache Rya (Incubating)
+Apache Rya 
 Copyright 2015-2020 The Apache Software Foundation
 
 This product includes software developed at

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ This tutorial will outline the steps needed to get quickly started with the Rya 
 
 ### Prerequisites
 
-* Columnar Store (either Accumulo) The tutorial will go forward using Accumulo
-* Rya code (Git: git://git.apache.org/incubator-rya.git)
+* Columnar Store (either Accumulo or MongoDB) The tutorial will go forward using Accumulo
+* Rya code (Git: https://gitbox.apache.org/repos/asf?p=rya.git or https://github.com/apache/rya.git)
 * Maven 3.0 +
 
 ### Building from Source
@@ -339,7 +339,7 @@ public class QueryDataServletRun {
 Compile and run this code above, changing the url that your Rdf War is running at.
 
 
-[Apache Rya]: http://rya.incubator.apache.org/ 
+[Apache Rya]: http://rya.apache.org/ 
 [Accumulo]: https://accumulo.apache.org/
 [ZooKeeper]: https://zookeeper.apache.org/
 [Hadoop]: http://hadoop.apache.org/

--- a/extras/rya.manual/src/site/markdown/kafka-connect-integration.md
+++ b/extras/rya.manual/src/site/markdown/kafka-connect-integration.md
@@ -125,13 +125,13 @@ Name the file "quickstart-statements.nt" and use a text editor to write the foll
 Use the ```rya.kafka.connect.client``` to write the file's contents to the topic we just made.
 
 ```
-java -jar rya.kafka.connect.client-4.0.0-incubating-shaded.jar write -f quickstart-statements.nt -t statements
+java -jar rya.kafka.connect.client-<version>-shaded.jar write -f quickstart-statements.nt -t statements
 ```
  
 You may verify the statements were written by using the read command.
 
 ```
-java -jar rya.kafka.connect.client-4.0.0-incubating-shaded.jar read -t statements
+java -jar rya.kafka.connect.client-<version>-shaded.jar read -t statements
 ```
 At this point you need to decide whether you are going to use an Accumulo or 
 MongoDB backed instance of Rya. The following steps are pretty much the same
@@ -148,7 +148,7 @@ cluster. To do this, you'll need to use the Rya Shell. Here's roughly what an
 installation session should look like.
 
 ```
-java -jar rya.shell-4.0.0-incubating-shaded.jar
+java -jar rya.shell-<version>-shaded.jar
 
  _____                _____ _          _ _
 |  __ \              / ____| |        | | |
@@ -158,7 +158,7 @@ java -jar rya.shell-4.0.0-incubating-shaded.jar
 |_|  \_\__, |\__,_| |_____/|_| |_|\___|_|_|
         __/ |
        |___/
-4.0.0-incubating
+<version>
 
 Welcome to the Rya Shell.
 
@@ -224,7 +224,7 @@ Install the shaded jar that contains the Accumulo Rya Sink connector.
 
 ```
 mkdir confluent-4.1.0/share/java/kafka-connect-rya-accumulo
-cp rya.kafka.connect.accumulo-4.0.0-incubating-shaded.jar confluent-4.1.0/share/java/kafka-connect-rya-accumulo
+cp rya.kafka.connect.accumulo-<version>-shaded.jar confluent-4.1.0/share/java/kafka-connect-rya-accumulo
 ```
 
 Then we need to configure the connector to read from the "statements" topic,
@@ -300,7 +300,7 @@ Mongo database. To do this, you'll need to use the Rya Shell. Here's roughly
 what an installation session should look like.
 
 ```
-[root@localhost ~]# java -jar rya.shell-4.0.0-incubating-SNAPSHOT-shaded.jar
+[root@localhost ~]# java -jar rya.shell-<version>-shaded.jar
  _____                _____ _          _ _
 |  __ \              / ____| |        | | |
 | |__) |   _  __ _  | (___ | |__   ___| | |
@@ -309,7 +309,7 @@ what an installation session should look like.
 |_|  \_\__, |\__,_| |_____/|_| |_|\___|_|_|
         __/ |
        |___/
-4.0.0-incubating-SNAPSHOT
+<version>
 
 Welcome to the Rya Shell.
 
@@ -371,7 +371,7 @@ Install the shaded jar that contains the Mongo Rya Sink connector.
 
 ```
 mkdir confluent-4.1.0/share/java/kafka-connect-rya-mongo
-cp rya.kafka.connect.mongo-4.0.0-incubating-shaded.jar confluent-4.1.0/share/java/kafka-connect-rya-mongo
+cp rya.kafka.connect.mongo-<version>-shaded.jar confluent-4.1.0/share/java/kafka-connect-rya-mongo
 ```
 
 Then we need to configure the connector to read from the "statements" topic,

--- a/extras/rya.manual/src/site/markdown/pcj-updater.md
+++ b/extras/rya.manual/src/site/markdown/pcj-updater.md
@@ -257,12 +257,12 @@ fluo.yarn.worker.num.cores     | Defines the number of CPUs that should be alloc
 
 The RYA PCJ Updater Fluo App jar is in a special uber jar that contains a subset of dependencies.
 This jar is represented by the maven coordinate 
-`org.apache.rya:rya.pcj.fluo.app:3.2.11-incubating:fluo-app` and when Rya is 
+`org.apache.rya:rya.pcj.fluo.app:<version>:fluo-app` and when Rya is 
 built from source, it can be found here:
-`rya/extras/rya.pcj.fluo/pcj.fluo.app/target/rya.pcj.fluo.app-3.2.11-incubating-fluo-app.jar`.
+`rya/extras/rya.pcj.fluo/pcj.fluo.app/target/rya.pcj.fluo.app-<version>-fluo-app.jar`.
 
 The Rya fluo-app jar needs to be copied to Fluo here: 
-`fluo-1.0.0-incubating/apps/rya_pcj_updater/lib/rya.pcj.fluo.app-3.2.11-incubating-fluo-app.jar`
+`fluo-1.0.0-incubating/apps/rya_pcj_updater/lib/rya.pcj.fluo.app-<version>-fluo-app.jar`
 
 
 ### 6. Initialize the Rya PCJ Updater Fluo App
@@ -297,7 +297,7 @@ $ rya
 |_|  \_\__, |\__,_| |_____/|_| |_|\___|_|_|
         __/ |
        |___/
-3.2.11-incubating
+<version>
 
 Welcome to the Rya Shell.
 

--- a/extras/rya.manual/src/site/markdown/quickstart.md
+++ b/extras/rya.manual/src/site/markdown/quickstart.md
@@ -25,8 +25,8 @@ This tutorial will outline the steps needed to get quickly started with the Apac
 
 ## Prerequisites
 
-* Columnar Store (Accumulo)
-* Apache Rya code (Git: git://git.apache.org/incubator-rya.git)
+* Columnar Store (Accumulo or MongoDB) The tutorial will go forward using Accumulo
+* Apache Rya code (Git: https://gitbox.apache.org/repos/asf?p=rya.git or https://github.com/apache/rya.git)
 * Maven 3.0 +
 
 ## Building from Source

--- a/extras/rya.manual/src/site/markdown/rya-streams.md
+++ b/extras/rya.manual/src/site/markdown/rya-streams.md
@@ -118,10 +118,10 @@ Copy the RPM to the CentOS 7 machine the Query Manager will be installed on.
 Install it using the following command:
 
 ```
-yum install -y rya.streams.query-manager-3.2.12-incubating.noarch.rpm
+yum install -y rya.streams.query-manager-<version>.noarch.rpm
 ```
 
-It will install the program to **/opt/rya-streams-query-manager-3.2.12**. Follow
+It will install the program to **/opt/rya-streams-query-manager-<version>**. Follow
 the directions that are in the README.txt file within that directory to finish
 configuration.
 
@@ -140,7 +140,7 @@ We assume Kafka is running on the local machine using the standard Kafka port
 of 9092. Issue the following command:
 
 ```
-java -jar rya.streams.client-3.2.12-incubating-SNAPSHOT-shaded.jar add-query \
+java -jar rya.streams.client-<version>-shaded.jar add-query \
     -i localhost -p 9092 -r rya-streams-quick-start -a true \
     -q "SELECT * WHERE { ?person <urn:talksTo> ?employee .?employee <urn:worksAt> ?business }"
 ```
@@ -148,7 +148,7 @@ The Query Manager should eventually see that this query was registered and
 start a Rya Streams job that will begin processing it using any Visibility
 Statements that have been loaded into Rya Streams. If no results are observed
 in step 6, then verify the Query Manager is working properly. Its logs can be
-found in **/opt/rya-streams-query-manager-3.2.12/logs**.
+found in **/opt/rya-streams-query-manager-<version>/logs**.
 
 ### Step 4: Start watching for results ###
 
@@ -156,7 +156,7 @@ We need to fetch the Query ID of the query we want to watch. This can be looked
 up by issuing the following command:
 
 ```
-java -jar rya.streams.client-3.2.12-incubating-SNAPSHOT-shaded.jar list-queries \
+java -jar rya.streams.client-<version>-shaded.jar list-queries \
     -i localhost -p 9092 -r rya-streams-quick-start"
 ```
 
@@ -173,7 +173,7 @@ need to use the Query ID **8dd689ee-9d16-4aa7-91c0-667cdb3ed81a**. Start
 watching the Stream Query's output using the following command:
 
 ```
-java -jar rya.streams.client-3.2.12-incubating-SNAPSHOT-shaded.jar stream-results \
+java -jar rya.streams.client-<version>-shaded.jar stream-results \
     -i localhost -p 9092 -r rya-streams-quick-start" -q 8dd689ee-9d16-4aa7-91c0-667cdb3ed81a
 ```
 
@@ -198,7 +198,7 @@ visibilities when we load the statements. Load the file using the following
 command:
 
 ```
-java -jar rya.streams.client-3.2.12-incubating-SNAPSHOT-shaded.jar load-statements \
+java -jar rya.streams.client-<version>-shaded.jar load-statements \
     -i localhost -p 9092 -r rya-streams-quick-start" -v "" -f ./quick-start-data.nt
 ```
 

--- a/extras/rya.manual/src/site/markdown/shell.md
+++ b/extras/rya.manual/src/site/markdown/shell.md
@@ -31,21 +31,21 @@ in the artifact `rya.shell-<version>-bin.tar.gz`.
 To install, simply extract the archive to the desired output directory
 
 ``` sh
-tar xzvf rya.shell-3.2.11-incubating-bin.tar.gz
+tar xzvf rya.shell-<version>-bin.tar.gz
 ```
 
 You can optionally install the Rya Shell by adding its `bin` directory to your 
 shell's `PATH`.
 
 ``` sh
-$ echo "PATH=$PATH:path/to/rya.shell-3.2.11-incubating/bin" >> ~/.bash_profile
+$ echo "PATH=$PATH:path/to/rya.shell-<version>/bin" >> ~/.bash_profile
 ```
 
 ## Launching, Exiting and Help
 
 ```
 # Launch the shell
-$ cd rya.shell-3.2.11-incubating-bin
+$ cd rya.shell-<version>-bin
 $ bin/rya
 
 # Or, if you added the rya shell to your path, you can just type:
@@ -59,7 +59,7 @@ $ rya
 |_|  \_\__, |\__,_| |_____/|_| |_|\___|_|_|
         __/ |                              
        |___/                               
-3.2.11-incubating
+<version>
 
 Welcome to the Rya Shell.
 
@@ -162,14 +162,14 @@ It is possible to script the Rya Shell by writing multiple commands to a text
 file and then load them into the shell with the `script` command:
 
 ```
-rya> script --file rya.shell-3.2.11-incubating/examples/example.script
+rya> script --file rya.shell-<version>/examples/example.script
 ```
 
 ## Logs
 
-Logging for the rya shell is written to the `rya.shell-3.2.11-incubating/logs`
+Logging for the rya shell is written to the `rya.shell-<version>/logs`
 directory.  Configuration of the logging is controlled by the 
-`rya.shell-3.2.11-incubating/conf/log4j.properties` file.
+`rya.shell-<version>/conf/log4j.properties` file.
 
 ## Creating a Rya Instance
 
@@ -303,7 +303,7 @@ The `print-instance-details` command displays the configuration of the currently
 rya/myAccumuloInstance:rya_> print-instance-details
 General Metadata:
   Instance Name: rya_
-  RYA Version: 3.2.11-incubating
+  RYA Version: <version>
   Users: myUserName
 Secondary Indicies:
   Entity Centric Index:

--- a/pom.xml
+++ b/pom.xml
@@ -47,9 +47,9 @@ under the License.
     <mailingLists>
         <mailingList>
             <name>Dev</name>
-            <subscribe>dev-subscribe@rya.incubator.apache.org</subscribe>
-            <unsubscribe>dev-unsubscribe@rya.incubator.apache.org</unsubscribe>
-            <post>dev@rya.incubator.apache.org</post>
+            <subscribe>dev-subscribe@rya.apache.org</subscribe>
+            <unsubscribe>dev-unsubscribe@rya.apache.org</unsubscribe>
+            <post>dev@rya.apache.org</post>
             <archive>http://mail-archives.apache.org/mod_mbox/rya-dev</archive>
         </mailingList>
     </mailingLists>
@@ -1484,9 +1484,9 @@ under the License.
     </reporting>
 
     <scm>
-        <connection>scm:git:git://git.apache.org/incubator-rya.git</connection>
-        <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/incubator-rya.git</developerConnection>
+        <connection>scm:git:https://gitbox.apache.org/repos/asf/rya.git</connection>
+        <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/rya.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://git-wip-us.apache.org/repos/asf?p=incubator-rya.git</url>
+        <url>https://gitbox.apache.org/repos/asf?p=rya.git</url>
     </scm>
 </project>


### PR DESCRIPTION
graduation clean-up:removed DISCLAIMER file, removed incubating name, updated mailing lists and git repo names in NOTICE, README.md, pom.xml

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
## Description
>What Changed?
removed DISCLAIMER file (since Rya is no longer incubating), removed incubating name, updated mailing lists and git repo names in NOTICE, README.md, pom.xml. 
pom.xml still has <version>4.0.1-incubating-SNAPSHOT</version> but I think the release plugin needs to run to change that to 4.0.1 (in all pom.xml files in the repo)


### Tests
>Coverage?
N/A

### Links
[Jira](https://issues.apache.org/jira/browse/RYA-526)

### Checklist
- [ ] Code Review
- [ ] Squash Commits

#### People To Reivew
@DLotts
